### PR TITLE
Save to localstorage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "env": {
+    "jest": true,
     "browser": true,
     "es6": true
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "eslint": "^6.4.0",
     "eslint-plugin-react": "^7.14.3",
-    "gh-pages": "^2.1.1"
+    "gh-pages": "^2.1.1",
+    "jest-localstorage-mock": "^2.4.0"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -9,27 +9,34 @@ import VillainsFields from 'components/VillainsFields';
 
 import styles from './App.module.css';
 
+import localStorage from './localStorage';
+
 function App() {
   return (
     <Form
       onSubmit={(values) => console.log(values)}
-      render={({ handleSubmit }) => (
-        <form onSubmit={handleSubmit} style={{display: 'flex'}}>
-          <section className={styles.formWrapper}>
-            <div className={styles.firstRow}>
-              <CharacterFields />
-              <ClanFields />
-            </div>
-            <div className={styles.firstRow}>
-              <AlliesFields />
-              <EnemiesFields />
-            </div>
-          </section>
-          <section style={{width: '25%', paddingLeft: 40}}>
-            <VillainsFields />
-          </section>
-        </form>
-      )}
+      initialValues={localStorage.getFormValues()}
+      render={({ handleSubmit, values }) => {
+        localStorage.setFormValues(values);
+
+        return (
+          <form onSubmit={handleSubmit} style={{display: 'flex'}}>
+            <section className={styles.formWrapper}>
+              <div className={styles.firstRow}>
+                <CharacterFields />
+                <ClanFields />
+              </div>
+              <div className={styles.firstRow}>
+                <AlliesFields />
+                <EnemiesFields />
+              </div>
+            </section>
+            <section style={{width: '25%', paddingLeft: 40}}>
+              <VillainsFields />
+            </section>
+          </form>
+        )
+      } }
     />
   );
 }

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -1,0 +1,12 @@
+const FIELD_KEY = 'form_values';
+
+export const getFormValues = () =>
+  JSON.parse( localStorage.getItem(FIELD_KEY) || '{}' );
+
+export const setFormValues = (object) =>
+  localStorage.setItem( FIELD_KEY, JSON.stringify(object) );
+
+export default {
+  getFormValues,
+  setFormValues,
+};

--- a/src/localStorage.test.js
+++ b/src/localStorage.test.js
@@ -1,0 +1,31 @@
+import { setFormValues, getFormValues } from './localStorage';
+
+beforeEach(localStorage.clear);
+beforeEach(localStorage.getItem.mockClear);
+beforeEach(localStorage.setItem.mockClear);
+
+describe('getFormValues', () => {
+  it('expect to load from to localStorage', () => {
+    localStorage.setItem('form_values', '{ "biru": "laibe" }');
+
+    const result = getFormValues();
+    expect(result).toStrictEqual({ biru: 'laibe' });
+    expect(localStorage.getItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect empty object if no value was previously passed', () => {
+    const result = getFormValues();
+    expect(result).toStrictEqual({});
+    expect(localStorage.getItem).toHaveBeenCalledTimes(1);
+  });
+
+});
+
+describe('setFormValues', () => {
+  it('expect to save to localStorage', () => {
+    setFormValues({ biru: 'laibe' });
+
+    expect(localStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('form_values')).toBe('{"biru":"laibe"}');
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import 'jest-localstorage-mock';


### PR DESCRIPTION
Each interaction with the form fields now save it to the localstorage. So, as an user, if something went wrong on my browser I can just open the page again and all fields will still be there.

![Example](https://user-images.githubusercontent.com/5847145/66283318-7873b500-e899-11e9-87e0-9c4c3c1e870e.gif)

I've also added some basic tests on localstorage wrapper file.