### PR TITLE
Add reset button

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,17 +11,24 @@ import styles from './App.module.css';
 
 import localStorage from './localStorage';
 
+export const resetFields = (form) =>
+  () => {
+    const EMPTY_FORM_VALUES = {};
+    form.initialize(EMPTY_FORM_VALUES);
+  };
+
 function App() {
   return (
     <Form
       onSubmit={(values) => console.log(values)}
       initialValues={localStorage.getFormValues()}
-      render={({ handleSubmit, values }) => {
+      render={({ handleSubmit, values, form }) => {
         localStorage.setFormValues(values);
 
         return (
           <form onSubmit={handleSubmit} style={{display: 'flex'}}>
             <section className={styles.formWrapper}>
+              <input type="button" onClick={resetFields(form)} value="limpar" />
               <div className={styles.firstRow}>
                 <CharacterFields />
                 <ClanFields />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,14 @@
+import { resetFields } from './App';
+
+describe('resetFields', () => {
+  it('expect to run initialize with empty object', () => {
+    const formSpy = {
+      initialize: jest.fn(),
+    };
+
+    const func = resetFields(formSpy);
+    func();
+
+    expect(formSpy.initialize).toBeCalledWith({});
+  });
+});


### PR DESCRIPTION
This closes #2.

The button just reset the form values to an empty object. This also triggers to save on localstorage, based on the last implementation.

![example](https://user-images.githubusercontent.com/5847145/66414040-02716a00-e9cf-11e9-9a4c-72dbe92da4f4.gif)

What still needs to be finished;
- [ ] button position
- [ ] button style
- [ ] button text
