### PR TITLE
Altera posição do campo de pesadelo

### DIFF
--- a/src/components/CharacterFields.js
+++ b/src/components/CharacterFields.js
@@ -16,9 +16,9 @@ const CharacterFields = () => (
         <TextInput label="Combate:" name="combate" />
         <TextInput label="Bloqueio:" name="bloqueio" />
         <TextInput label="Família:" name="familia" />
-        <TextInput label="Pesadelo:" name="pesadelo" />
         <TextInput label="Cicatriz:" name="cicatriz" />
         <TextInput label="Significado:" name="significado" />
+        <TextInput label="Pesadelo:" name="pesadelo" />
       </div>
       <div className={styles.history}>
         <label className={styles.historyLabel}>Histórico</label>


### PR DESCRIPTION
No livro as tabelas de cicatriz e significado são apresentadas antes da tabela de pesadelo.
Dessa forma fica mais fácil de acompanhar a criação de personagem.