### PR TITLE
Define valores iniciais para a ficha

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,11 +11,7 @@ import styles from './App.module.css';
 
 import localStorage from './localStorage';
 
-export const resetFields = (form) =>
-  () => {
-    const EMPTY_FORM_VALUES = {};
-    form.initialize(EMPTY_FORM_VALUES);
-  };
+export const resetFields = (form) => () => form.initialize(localStorage.initialValues);
 
 function App() {
   return (
@@ -42,7 +38,7 @@ function App() {
               <VillainsFields />
             </section>
           </form>
-        )
+        );
       } }
     />
   );

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -1,7 +1,16 @@
 const FIELD_KEY = 'form_values';
 
-export const getFormValues = () =>
-  JSON.parse( localStorage.getItem(FIELD_KEY) || '{}' );
+export const initialValues = {
+  compaixao: ['1', '2'],
+  determinacao: ['1', '2']
+};
+
+export const getFormValues = () => {
+  const storedValues =  JSON.parse(localStorage.getItem(FIELD_KEY) || '{}');
+  const isStorageUsed = Object.keys(storedValues).length > 0;
+
+  return isStorageUsed ? storedValues : initialValues;
+};
 
 export const setFormValues = (object) =>
   localStorage.setItem( FIELD_KEY, JSON.stringify(object) );
@@ -9,4 +18,5 @@ export const setFormValues = (object) =>
 export default {
   getFormValues,
   setFormValues,
+  initialValues,
 };

--- a/src/localStorage.test.js
+++ b/src/localStorage.test.js
@@ -1,4 +1,4 @@
-import { setFormValues, getFormValues } from './localStorage';
+import { setFormValues, getFormValues, initialValues } from './localStorage';
 
 beforeEach(localStorage.clear);
 beforeEach(localStorage.getItem.mockClear);
@@ -13,9 +13,17 @@ describe('getFormValues', () => {
     expect(localStorage.getItem).toHaveBeenCalledTimes(1);
   });
 
-  it('expect empty object if no value was previously passed', () => {
+  it('expect initial values if the object is empty', () => {
+    localStorage.setItem('form_values', '{}');
+
     const result = getFormValues();
-    expect(result).toStrictEqual({});
+    expect(result).toStrictEqual(initialValues);
+    expect(localStorage.getItem).toHaveBeenCalledTimes(1);
+  });
+
+  it('expect initial values if no value was previously passed', () => {
+    const result = getFormValues();
+    expect(result).toStrictEqual(initialValues);
     expect(localStorage.getItem).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Todo personagem começa com 2 em compaixão e determinação, com essa mudança sempre que criamos um novo personagem esses valores já serão preenchidos.